### PR TITLE
Avoid Reconstructing C2List

### DIFF
--- a/cape_parsers/CAPE/core/Emotet.py
+++ b/cape_parsers/CAPE/core/Emotet.py
@@ -298,10 +298,8 @@ def extract_config(filebuf):
         c2list_va_offset = first_match(yara_matches, "$snippet3")
         c2_list_va = struct.unpack("I", filebuf[c2list_va_offset + 2 : c2list_va_offset + 6])[0]
         c2_list_rva = c2_list_va & 0xFFFF if c2_list_va - image_base > 0x20000 else c2_list_va - image_base
-        try:
+        with suppress(pefile.PEFormatError):
             c2_list_offset = pe.get_offset_from_rva(c2_list_rva)
-        except pefile.PEFormatError:
-            pass
 
         while True:
             try:
@@ -320,10 +318,8 @@ def extract_config(filebuf):
         c2list_va_offset = first_match(yara_matches, "$snippet4")
         c2_list_va = struct.unpack("I", filebuf[c2list_va_offset + 8 : c2list_va_offset + 12])[0]
         c2_list_rva = c2_list_va & 0xFFFF if c2_list_va - image_base > 0x20000 else c2_list_va - image_base
-        try:
+        with suppress(pefile.PEFormatError):
             c2_list_offset = pe.get_offset_from_rva(c2_list_rva)
-        except pefile.PEFormatError:
-            pass
         while True:
             try:
                 ip = struct.unpack("<I", filebuf[c2_list_offset : c2_list_offset + 4])[0]

--- a/cape_parsers/CAPE/core/Emotet.py
+++ b/cape_parsers/CAPE/core/Emotet.py
@@ -532,7 +532,7 @@ def extract_config(filebuf):
         c2_funcs = c2_funcs_from_match(yara_matches, "$snippetY", filebuf)
     elif first_match(yara_matches, "$snippetZ"):
         c2_funcs = c2_funcs_from_match(yara_matches, "$snippetZ", filebuf)
-    if delta:
+    if delta and not conf_dict:
         if c2list_va_offset:
             c2_list_va = struct.unpack("I", filebuf[c2list_va_offset + delta : c2list_va_offset + delta + 4])[0]
             c2_list_rva = c2_list_va - image_base


### PR DESCRIPTION
I have tried the config with the following sample and I got an issue with constructing the C2List servers
https://www.virustotal.com/gui/file/74e5829d277a1ee653f611e9512d31be41a0c7ea0e6dff5c9caa721e3ac14a8a/

It hits `$snippet8, $snippetB`, and `$ref_rsa`, so It will construct the IP:Port list as shown in the following loop
![image](https://github.com/user-attachments/assets/6c0ca1d1-b502-4e9b-ad56-c10bdf3327de)

The problem is it will try to construct the IP:Port again here and if the C2List size is bigger than 1000 bytes, it will return with an empty list
![image](https://github.com/user-attachments/assets/52ee9bd8-ee1b-49a4-972a-ad9acc1e092c)

So before reconstructing the list again, I have added a condition to check whether `conf_dict` is empty.
