### PR TITLE
Fixing REvil config extractor.

### DIFF
--- a/cape_parsers/CAPE/community/REvil.py
+++ b/cape_parsers/CAPE/community/REvil.py
@@ -78,7 +78,13 @@ def extract_config(data):
 
         if all(sections in section_names for sections in required_sections):
             # print("all required section names found")
-            config_section_name = [resource for resource in section_names if resource not in required_sections][0]
+            section_names_set = set(section_names)
+            required_sections_set = set(required_sections)
+            config_section_names = section_names_set - required_sections_set
+            if len(config_section_names) == 1:
+                config_section_name = config_section_names.pop()
+            else:
+                return None # Or raise an exception, depending on desired behavior
             config_key, config_data = getREvilKeyAndConfig(pe.sections, config_section_name)
             if config_key and config_data:
                 return decodeREvilConfig(config_key, config_data)


### PR DESCRIPTION
Looks like this was written for Python2.7 and didn't have test cases when things changed to bytes. This should fix everything for Python3 where pefile is returning section names as bytes and the RC4 routine is also bytes, so the `ord` is no longer needed.