### PR TITLE
fix lumma xor index out of range

### DIFF
--- a/cape_parsers/CAPE/community/Lumma.py
+++ b/cape_parsers/CAPE/community/Lumma.py
@@ -131,8 +131,10 @@ def get_rdata(pe, data):
 
 def xor_data(data, key):
     decoded = bytearray()
+    if not key:
+        return decoded
     for i in range(len(data)):
-        decoded.append(data[i] ^ key[i % len(data)])
+        decoded.append(data[i] ^ key[i % len(key)])
     return decoded
 
 
@@ -351,7 +353,7 @@ def extract_config(data):
                         decrypted = chacha20_xor(c2_encrypted, key, nonce, counter)
                         c2 = extract_c2_domain(decrypted)
                         if c2 is not None and len(c2) > 10:
-                            config["CNCs"].append("https://" + c2.decode())
+                            config.setdefault("CNCs", []).append("https://" + c2.decode())
                             break
 
                 except Exception:


### PR DESCRIPTION
index out of range on samples triggering xor_data method.

Testing sample: 77a0d9126c0a2ec649f92a4909bada5ae421882ad1430248aa8165b7950fc991

fixed xor_data method, added setdefault on the config line 356.

