### PR TITLE
QakBot: parse old ASCII-format C2 list in resource 311

### DIFF
--- a/cape_parsers/CAPE/core/QakBot.py
+++ b/cape_parsers/CAPE/core/QakBot.py
@@ -456,7 +456,11 @@ def extract_config(filebuf):
                             config = parse_config(dec_bytes)
                         elif str(entry.name) == "311":
                             dec_bytes = decrypt_data(res_data)
-                            controllers = parse_binary_c2(dec_bytes)
+                            # Old-format (pre Nov'20) Qakbot stores C2 list as ASCII "IP;flag;port\r\n"
+                            if dec_bytes and b";" in dec_bytes[:32] and b"\r\n" in dec_bytes[:64]:
+                                controllers = parse_controllers(dec_bytes)
+                            else:
+                                controllers = parse_binary_c2(dec_bytes)
                         elif str(entry.name) in ("118", "3719"):
                             dec_bytes = decrypt_data2(res_data)
                             controllers = parse_binary_c2_2(dec_bytes)


### PR DESCRIPTION
## Problem

For pre-Nov'20 Qakbot core DLLs, resource `311` is RC4-encrypted (current
`decrypt_data` works), **but the plaintext is an ASCII C2 list**:

```
47.44.217.98;0;443\r\n86.97.146.204;0;2222\r\n65.60.228.130;0;443\r\n...
```

The dispatch unconditionally calls `parse_binary_c2`, which reads 8-byte
records as `(flag, IP_BE, port_BE, pad)`. Walking ASCII text that way
yields a large list of bogus IPs — every byte ends up in `0x00..0x7F`
because the source was printable text, not random RC4 output.

## Reproduction

Sample (Qakbot core DLL, build timestamp 2020-08-08):

- MD5 &nbsp;&nbsp; `f0e4a51d1b8f27a2182850bdd61c4766`
- SHA256 `5ceff2dd528ebd779302a353cbd04ced112a69ceb385f96053d6490f0e065d60`
- Available on MalwareBazaar / VirusTotal (not attached here).

### Before this PR

```python
>>> from cape_parsers.CAPE.core.QakBot import extract_config
>>> r = extract_config(open(sample, "rb").read())
>>> len(r["raw"]["address"])
396
>>> r["raw"]["address"][:3]
['55.46.52.52:11826', '46.57.56.59:12347', '51.13.10.56:13870']
```

None of those 4-byte IPs exist as raw bytes anywhere in the file (in any
byte order). They come from misreading the ASCII plaintext:

| 8-byte window of decrypted resource 311 | ASCII view | misread as |
|---|---|---|
| `34 37 2E 34 34 2E 32 31` | `"47.44.21"` | `55.46.52.52:11826` |
| `37 2E 39 38 3B 30 3B 34` | `"7.98;0;4"` | `46.57.56.59:12347` |
| `34 33 0D 0A 38 36 2E 39` | `"43\r\n86.9"` | `51.13.10.56:13870`  ← straddles `\r\n` between two real C2s |

Sanity-check signature of "ASCII text misread as binary": of the
`396 * 4 = 1584` IP bytes emitted, **0%** are `>= 0x80` (random RC4
output should be ~50%).

### After this PR

```python
>>> len(r["raw"]["address"])
150
>>> r["raw"]["address"][:3]
['47.44.217.98:443', '86.97.146.204:2222', '65.60.228.130:443']
```

These match the entries actually written into the resource (decompiled
config also shows 150 controllers + 4 SMTP credential pairs in resource
`308`).

## Fix

`parse_controllers` already exists in this file with a docstring that
documents exactly this format (`72.29.181.77;0;2078\r\n`). Sniff the
first bytes of the decrypted blob to pick the right parser:

```python
elif str(entry.name) == "311":
    dec_bytes = decrypt_data(res_data)
    if dec_bytes and b";" in dec_bytes[:32] and b"\r\n" in dec_bytes[:64]:
        controllers = parse_controllers(dec_bytes)
    else:
        controllers = parse_binary_c2(dec_bytes)
```

`parse_binary_c2` is kept as the fallback, so post-Nov'20 binary-format
samples are unchanged.

## Risk / scope

- Behavior changes **only** for resource `311` blobs whose first 64 bytes
  contain both `;` and `\r\n` after RC4 decryption. The binary-format
  records used in newer Qakbot do not contain `\r\n` in the leading
  bytes (sha1 prefix + packed records), so they take the `else` branch.
- No new dependencies, no signature changes.
